### PR TITLE
Handle Exception for /diff call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -404,6 +404,8 @@ exports.init = function(app, config) {
     *
     * Response:
     *   json: [ ({ "path": <path> })* ]
+    * Error:
+    *   json: { "error": <error> }
     */
   app.get(config.prefix + '/repo/:repo/diff/:from/:to',
     [prepareGitVars, getRepo],
@@ -420,7 +422,8 @@ exports.init = function(app, config) {
                 path: patch.newFile().path()
               };
             }))
-            .then((patches) => res.json(patches));
+            .then((patches) => res.json(patches))
+            .catch(e => res.status(500).json({ "error": e.message }));
         });
     });
 


### PR DESCRIPTION
When :from / :to values do not match any existing commit
 (for instance if the git bare repo is not fully sync'ed / up-to-date)
 this gives an UnhandledPromiseRejectionWarning and the Response
 stays empty, leaving the Client to wait until a timeout
 (usually 2 min)
This is to return straight away an error like with other /calls